### PR TITLE
Add build-base apk to get gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ARG CODE_GID="1000"
 # Base packages
 RUN apk add --no-cache \
     bash \
+    build-base \
     curl \
     git \
     just \


### PR DESCRIPTION
Fixes 

```bash
> just pre-commit
pre-commit run --all-files
[INFO] Initializing environment for https://github.com/pdm-project/pdm.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Initializing environment for https://github.com/charliermarsh/ruff-pre-commit.
[INFO] Installing environment for https://github.com/pdm-project/pdm.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/vscode/.cache/pre-commit/repo1e1q39aa/py_env-python3.11/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /home/vscode/.cache/pre-commit/repo1e1q39aa
      Preparing metadata (setup.py): started
      Preparing metadata (setup.py): finished with status 'done'
    Collecting ruamel.yaml>=0.15 (from pre-commit-hooks==4.4.0)
      Downloading ruamel.yaml-0.17.32-py3-none-any.whl (112 kB)
         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 112.2/112.2 kB 5.4 MB/s eta 0:00:00
    Collecting ruamel.yaml.clib>=0.2.7 (from ruamel.yaml>=0.15->pre-commit-hooks==4.4.0)
      Downloading ruamel.yaml.clib-0.2.7.tar.gz (182 kB)
         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 182.5/182.5 kB 12.3 MB/s eta 0:00:00
      Preparing metadata (setup.py): started
      Preparing metadata (setup.py): finished with status 'error'
stderr:
      error: subprocess-exited-with-error
      
      × python setup.py egg_info did not run successfully.
      │ exit code: 1
      ╰─> [7 lines of output]
          /usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find Scrt1.o: No such file or directory
          /usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find crti.o: No such file or directory
          /usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lssp_nonshared: No such file or directory
          collect2: error: ld returned 1 exit status
          sys.argv ['/tmp/pip-install-dvnooxig/ruamel-yaml-clib_d7fb22f251e5451188ab1109276af794/setup.py', 'egg_info', '--egg-base', '/tmp/pip-pip-egg-info-pxgy1hh8']
          test compiling /tmp/tmp_ruamel_8la6kj4a/test_ruamel_yaml.c -> test_ruamel_yaml link error /tmp/tmp_ruamel_8la6kj4a/test_ruamel_yaml.c
          Exception: command '/usr/bin/gcc' failed with exit code 1
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed
    
    × Encountered error while generating package metadata.
    ╰─> See above for output.
    
    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.
Check the log at /home/vscode/.cache/pre-commit/pre-commit.log
```
